### PR TITLE
Add document meta descriptions: improve SEO 88->100

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -37,6 +37,7 @@ services:
       # Optional volumes to access external data like staging or watch folders
       # - /opt/staging_files:/staging_files
       # - /opt/watch_folder:/watch_folder
+      - ../mayan/apps/appearance/templates/appearance:/opt/mayan-edms/lib/python3.7/site-packages/mayan/apps/appearance/templates/appearance
 
   postgresql:
     environment:
@@ -153,3 +154,4 @@ volumes:
   postgres:
   rabbitmq:
   redis:
+

--- a/mayan/apps/appearance/templates/appearance/base_plain.html
+++ b/mayan/apps/appearance/templates/appearance/base_plain.html
@@ -12,6 +12,7 @@
         <meta content="width=device-width, initial-scale=1, maximum-scale=5" name="viewport">
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <meta http-equiv="Content-Language" content="{{ LANGUAGE_CODE }}" />
+        <meta name="description" content="Free Open Source Document Management System">
         <title>
             {% block base_title %}
                 {% block title %}{% endblock %} :: {% block project_name %}    {% smart_setting 'COMMON_PROJECT_TITLE' as setting_project_title %}{% endblock %}

--- a/mayan/apps/appearance/templates/appearance/root.html
+++ b/mayan/apps/appearance/templates/appearance/root.html
@@ -13,6 +13,7 @@
         <meta content="width=device-width, initial-scale=1, maximum-scale=5" name="viewport">
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <meta http-equiv="Content-Language" content="{{ LANGUAGE_CODE }}" />
+        <meta name="description" content="Free Open Source Document Management System">
         <title>
             {% block base_title %}
                 {% block title %}{% endblock %} :: {% block project_name %}{% smart_setting 'COMMON_PROJECT_TITLE' %}{% endblock %}


### PR DESCRIPTION
Add meta descriptions to `root.html` and `base_plain.html` to add  it to all pages.

`docker-compose.yml` was edited to add volumes for those files.